### PR TITLE
Fix nhost chatbot configuration error

### DIFF
--- a/nhost-chatbot/src/main.tsx
+++ b/nhost-chatbot/src/main.tsx
@@ -6,9 +6,18 @@ import { NhostApolloProvider } from '@nhost/react-apollo'
 import App from './App'
 import './App.css'
 
-const nhost = new NhostClient({
-  backendUrl: import.meta.env.VITE_NHOST_BACKEND_URL,
-})
+// Support both BACKEND_URL and SUBDOMAIN/REGION as per README
+const backendUrl = import.meta.env.VITE_NHOST_BACKEND_URL as string | undefined
+const subdomain = import.meta.env.VITE_NHOST_SUBDOMAIN as string | undefined
+const region = import.meta.env.VITE_NHOST_REGION as string | undefined
+
+const nhost = new NhostClient(
+  backendUrl
+    ? { backendUrl }
+    : subdomain && region
+    ? { subdomain, region }
+    : {}
+)
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>


### PR DESCRIPTION
Fix Nhost client initialization error by supporting multiple environment variable configurations.

The application was failing to initialize the Nhost client, leading to a "Please provide `subdomain` or `authUrl`" error and a blank page.

---
<a href="https://cursor.com/background-agent?bcId=bc-6e9fe273-2bb7-4617-a275-dee6b1c084a0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6e9fe273-2bb7-4617-a275-dee6b1c084a0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

